### PR TITLE
move example.go to basicauth and write unit test for middleware

### DIFF
--- a/gin/basicauth/README.md
+++ b/gin/basicauth/README.md
@@ -6,7 +6,7 @@ Writing basic authentication middleware by yourself for your every project takes
 
 
 # Examples
-Find example source code [here](https://github.com/golanguzb70/middleware/blob/main/gin/basicauth/example/example.go)
+Find example source code [here](https://github.com/golanguzb70/middleware/blob/main/gin/basicauth/example.go)
 
 ## Require Authentication for all requests
 To configure your middleware to require authentication from all requests use the code below.

--- a/gin/basicauth/example.go
+++ b/gin/basicauth/example.go
@@ -1,18 +1,17 @@
-package example
+package basicauth
 
 import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/golanguzb70/middleware/gin/basicauth"
 )
 
 func RestrictAllRouter() *gin.Engine {
 	router := gin.Default()
 
 	// This configuration checks for all incoming requests for authentication
-	cfg := basicauth.Config{
-		Users: []basicauth.User{
+	cfg := Config{
+		Users: []User{
 			{
 				UserName: "UserName1",
 				Password: "Password1",
@@ -41,8 +40,8 @@ func RestrictAllRouter() *gin.Engine {
 func RestrictByMethodRouter() *gin.Engine {
 	router := gin.Default()
 
-	cfg := basicauth.Config{
-		Users: []basicauth.User{
+	cfg := Config{
+		Users: []User{
 			{
 				UserName: "UserName1",
 				Password: "Password1",
@@ -82,8 +81,8 @@ func RestrictByMethodRouter() *gin.Engine {
 func RestrictByUrlRouter() *gin.Engine {
 	router := gin.Default()
 
-	cfg := basicauth.Config{
-		Users: []basicauth.User{
+	cfg := Config{
+		Users: []User{
 			{
 				UserName: "UserName1",
 				Password: "Password1",

--- a/gin/basicauth/middleware_test.go
+++ b/gin/basicauth/middleware_test.go
@@ -1,0 +1,218 @@
+package basicauth
+
+import (
+	"encoding/base64"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"gotest.tools/assert"
+)
+
+func TestRequireAuthorizationAll(t *testing.T) {
+	cfg := Config{
+		Users: []User{
+			{
+				UserName: "UserName1",
+				Password: "Password1",
+			},
+		},
+		RequireAuthForAll: true,
+	}
+	// Set Gin to Test mode
+	gin.SetMode(gin.TestMode)
+
+	// Create a new router
+	router := RestrictAllRouter()
+
+	// Create a test request without authorization header
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 401, w.Result().StatusCode)
+
+	req = httptest.NewRequest("GET", "/hi", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 401, w.Result().StatusCode)
+
+	// Create a test request with valid authorization header
+	base64Auth := base64.StdEncoding.EncodeToString([]byte(cfg.Users[0].UserName + ":" + cfg.Users[0].Password))
+
+	reqWithAuth := httptest.NewRequest("GET", "/", nil)
+	reqWithAuth.Header.Set("Authorization", "Basic "+base64Auth)
+	wWithAuth := httptest.NewRecorder()
+	router.ServeHTTP(wWithAuth, reqWithAuth)
+
+	assert.Equal(t, 200, wWithAuth.Result().StatusCode)
+}
+
+func TestRequireForSpecificMethods(t *testing.T) {
+	cfg := Config{
+		Users: []User{
+			{
+				UserName: "UserName1",
+				Password: "Password1",
+			},
+		},
+	}
+	// Set Gin to Test mode
+	gin.SetMode(gin.TestMode)
+
+	// Create a new router
+	router := RestrictByMethodRouter()
+
+	// Create a test request without authorization header
+	req := httptest.NewRequest("POST", "/user", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 401, w.Result().StatusCode)
+
+	req = httptest.NewRequest("PUT", "/user", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 401, w.Result().StatusCode)
+
+	req = httptest.NewRequest("DELETE", "/user", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 401, w.Result().StatusCode)
+
+	req = httptest.NewRequest("GET", "/user/10", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Result().StatusCode)
+
+	// Create a test request with valid authorization header
+	base64Auth := base64.StdEncoding.EncodeToString([]byte(cfg.Users[0].UserName + ":" + cfg.Users[0].Password))
+
+	req = httptest.NewRequest("POST", "/user", nil)
+	req.Header.Set("Authorization", "Basic "+base64Auth)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Result().StatusCode)
+
+	req = httptest.NewRequest("PUT", "/user", nil)
+	req.Header.Set("Authorization", "Basic "+base64Auth)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Result().StatusCode)
+
+	req = httptest.NewRequest("DELETE", "/user", nil)
+	req.Header.Set("Authorization", "Basic "+base64Auth)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Result().StatusCode)
+
+	req = httptest.NewRequest("GET", "/user/10", nil)
+	req.Header.Set("Authorization", "Basic "+base64Auth)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Result().StatusCode)
+}
+
+func TestRequireForSpecificUrls(t *testing.T) {
+	cfg := Config{
+		Users: []User{
+			{
+				UserName: "UserName1",
+				Password: "Password1",
+			},
+		},
+	}
+	// Set Gin to Test mode
+	gin.SetMode(gin.TestMode)
+
+	// Create a new router
+	router := RestrictByUrlRouter()
+	// Create a test request without authorization header
+	req := httptest.NewRequest("POST", "/user/create", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 401, w.Result().StatusCode)
+
+	req = httptest.NewRequest("DELETE", "/user/12", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 401, w.Result().StatusCode)
+
+	req = httptest.NewRequest("GET", "/user/12", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 401, w.Result().StatusCode)
+
+	req = httptest.NewRequest("POST", "/admin/create", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 401, w.Result().StatusCode)
+
+	req = httptest.NewRequest("DELETE", "/admin/10", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 401, w.Result().StatusCode)
+
+	req = httptest.NewRequest("GET", "/admin/10", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 401, w.Result().StatusCode)
+
+	req = httptest.NewRequest("GET", "/openurl", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Result().StatusCode)
+
+	// Create a test request with authorization header
+	base64Auth := base64.StdEncoding.EncodeToString([]byte(cfg.Users[0].UserName + ":" + cfg.Users[0].Password))
+
+	req = httptest.NewRequest("POST", "/user/create", nil)
+	req.Header.Set("Authorization", "Basic "+base64Auth)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Result().StatusCode)
+
+	req = httptest.NewRequest("DELETE", "/user/12", nil)
+	req.Header.Set("Authorization", "Basic "+base64Auth)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Result().StatusCode)
+
+	req = httptest.NewRequest("GET", "/user/12", nil)
+	req.Header.Set("Authorization", "Basic "+base64Auth)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Result().StatusCode)
+
+	req = httptest.NewRequest("POST", "/admin/create", nil)
+	req.Header.Set("Authorization", "Basic "+base64Auth)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Result().StatusCode)
+
+	req = httptest.NewRequest("DELETE", "/admin/10", nil)
+	req.Header.Set("Authorization", "Basic "+base64Auth)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Result().StatusCode)
+
+	req = httptest.NewRequest("GET", "/admin/10", nil)
+	req.Header.Set("Authorization", "Basic "+base64Auth)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Result().StatusCode)
+
+	req = httptest.NewRequest("GET", "/openurl", nil)
+	req.Header.Set("Authorization", "Basic "+base64Auth)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Result().StatusCode)
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/golanguzb70/middleware
 
 go 1.20
 
-require github.com/gin-gonic/gin v1.9.1
+require (
+	github.com/gin-gonic/gin v1.9.1
+	gotest.tools v2.2.0+incompatible
+)
 
 require (
 	github.com/bytedance/sonic v1.9.1 // indirect
@@ -13,6 +16,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.14.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect
@@ -20,6 +24,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	golang.org/x/arch v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -82,4 +84,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=


### PR DESCRIPTION
Before example.go file was located in package example. Now it is moved back to basicauth
Write test case for gin basic auth middleware.